### PR TITLE
Removed textile integration and added direct metadata linking

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { NftMarketplaceModule } from './nft-marketplace/nft-marketplace.module';
 import { ScheduleModule } from '@nestjs/schedule';
 
 import { CronjobService } from './cronjob/cronjob.service';
+import { MetadataModule } from './metadata/metadata.module';
 @Module({
   imports: [
     ScheduleModule.forRoot(),
@@ -21,6 +22,7 @@ import { CronjobService } from './cronjob/cronjob.service';
     TextileModule,
     UsersModule,
     NftMarketplaceModule,
+    MetadataModule,
   ],
   providers: [CronjobService],
 })

--- a/src/deployment/deployment.controller.ts
+++ b/src/deployment/deployment.controller.ts
@@ -70,11 +70,13 @@ export class DeploymentController {
       ' ',
     );
     console.log('deployed');
-    const uri =
-      'https://bafzbeigcbumfj5l2uerqp4pd76pctqrklhdqsupmhjydp6hriwb42rivbq.textile.space';
+    // const uri =
+    //   'https://bafzbeigcbumfj5l2uerqp4pd76pctqrklhdqsupmhjydp6hriwb42rivbq.textile.space';
+    const uri = process.env.API_BASE_URL || 'http://localhost:8080/';
     const confirm = await contract.deployed();
     const address = contract.address;
-    const res = await contract.setBaseURI(`${uri}/${address}/`);
+    const baseUri = `${uri}/metadata/${address}/`;
+    const res = await contract.setBaseURI(baseUri);
     const hash = confirm.deployTransaction.hash;
 
     // Contract Deployment End
@@ -102,7 +104,7 @@ export class DeploymentController {
     arr[`contract_address`] = address;
     arr[`description`] = deploymentBody.description;
     //  /`${uri}/${address}/`
-    arr[`baseuri`] = uri;
+    arr[`baseuri`] = baseUri;
     arr[`imageuri`] = deploymentBody.imageuri;
     return await this.deploymentService.InsertContract(arr);
   }

--- a/src/metadata/metadata.controller.ts
+++ b/src/metadata/metadata.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { MetadataService } from './metadata.service';
+
+@ApiTags('Metadata')
+@Controller('metadata')
+export class MetadataController {
+  constructor(private readonly metadataservice: MetadataService) {}
+// Swagger UI Options
+@ApiOperation({
+    summary:
+      'This api is used to get the metadata of a token',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Successfully Fetched Metadata',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'there is no nft assocaited with given Id',
+  })
+  /**************************** */
+  // Actual Get Route
+
+  @Get('/:contract_address/:token_id')
+  async getMetadata(
+    @Param('contract_address') contract_address: string,
+    @Param('token_id') token_id: string,
+  ): Promise<string> {
+    try {
+        const res = await this.metadataservice.getMetadata(contract_address, token_id);
+        return res;
+    } catch (error) {
+      console.log(error);
+    }
+  }
+}

--- a/src/metadata/metadata.module.ts
+++ b/src/metadata/metadata.module.ts
@@ -1,0 +1,21 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { metadata, metadataSchema } from 'src/schemas/metadata.schema';
+import { MetadataController } from './metadata.controller';
+import { MetadataService } from './metadata.service';
+
+@Module({
+  imports: [
+    HttpModule,
+    MongooseModule.forFeature([
+      {
+        name: metadata.name,
+        schema: metadataSchema,
+      },
+    ]),
+  ],
+  controllers: [MetadataController],
+  providers: [MetadataService],
+})
+export class MetadataModule {}

--- a/src/metadata/metadata.service.ts
+++ b/src/metadata/metadata.service.ts
@@ -1,0 +1,33 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { metadata, metadataDocument } from 'src/schemas/metadata.schema';
+
+@Injectable()
+export class MetadataService {
+  constructor(
+    private readonly httpService: HttpService,
+    @InjectModel(metadata.name) private MetadataModel: Model<metadataDocument>,
+  ) {
+    MetadataModel;
+  }
+
+  async getMetadata(
+    contract_address: string,
+    token_id: string,
+    chain = 'Polygon',
+  ): Promise<any> {
+    const metadataDoc = await this.MetadataModel.findOne({
+      contract_address,
+      chain,
+    });
+    if (metadataDoc) {
+      const uri = metadataDoc.tokenUri[parseInt(token_id)].uri;
+      const res = await this.httpService.axiosRef.get(uri);
+      return res.data;
+    } else {
+      return 'Token Doesnt exist';
+    }
+  }
+}

--- a/src/nft/nft.module.ts
+++ b/src/nft/nft.module.ts
@@ -10,6 +10,7 @@ import { DeploymentService } from 'src/deployment/deployment.service';
 import { contractSchema, ContractSchema } from 'src/schemas/contract.schema';
 import { MongooseModule } from '@nestjs/mongoose';
 import { NftSchema, nftSchema } from 'src/schemas/nft.schema';
+import { metadata, metadataSchema } from 'src/schemas/metadata.schema';
 
 require('dotenv').config();
 @Module({
@@ -20,6 +21,10 @@ require('dotenv').config();
       {
         name: ContractSchema.name,
         schema: contractSchema,
+      },
+      {
+        name: metadata.name,
+        schema: metadataSchema,
       },
     ]),
     JwtModule.register({

--- a/src/nft/nft.service.ts
+++ b/src/nft/nft.service.ts
@@ -4,6 +4,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { ContractDocument, ContractSchema } from 'src/schemas/contract.schema';
 import { NftDocument, NftSchema } from 'src/schemas/nft.schema';
+import { metadataDocument, metadata } from 'src/schemas/metadata.schema';
 import {
   createNFT,
   getNft,
@@ -18,6 +19,7 @@ export class NftService {
     private ContractModel: Model<ContractDocument>,
     private readonly httpService: HttpService,
     @InjectModel(NftSchema.name) private NftModel: Model<NftDocument>,
+    @InjectModel(metadata.name) private MetadataModel: Model<metadataDocument>,
   ) {
     NftModel;
   }
@@ -95,5 +97,43 @@ export class NftService {
       },
       { $push: { imageuri: image_uri } },
     );
+  }
+
+  async pushTokenUriToDocArray(
+    contract_address: string,
+    tokenUri: string,
+    tokenId: number,
+    contract_type: string,
+    chain = 'Polygon', //will use it later
+  ) {
+    const doc = await this.MetadataModel.findOne({
+      contract_address,
+      contract_type,
+      chain,
+    });
+    
+    if (doc) {
+      const doc = await this.MetadataModel.findOneAndUpdate(
+        {
+          contract_address,
+          contract_type,
+          chain,
+        },
+        {
+          $addToSet: {
+            tokenUri: { tokenId, uri: tokenUri },
+          },
+        },
+      );
+      return doc;
+    } else {
+      const metadata = await this.MetadataModel.create({
+        contract_address,
+        contract_type,
+        tokenUri: [{ tokenId, uri: tokenUri }],
+        chain,
+      });
+      return metadata;
+    }
   }
 }

--- a/src/schemas/metadata.schema.ts
+++ b/src/schemas/metadata.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document, PromiseProvider, Types } from 'mongoose';
+export type metadataDocument = metadata & Document;
+
+@Schema({ timestamps: true })
+export class metadata {
+  @Prop()
+  contract_address: string;
+
+  @Prop({ enum: ['NGM721PSI', 'NGM1155', 'NGMTINY721'] })
+  contract_type: string;
+
+  @Prop()
+  tokenUri: Array<{
+    tokenId: number;
+    uri: string;
+  }>;
+
+  @Prop()
+  chain: string;
+}
+
+export const metadataSchema = SchemaFactory.createForClass(metadata);


### PR DESCRIPTION
Now new route /metadata will load the metadata for the minted nfts
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/30682601/200339845-1f769a19-f116-482d-a01c-5ce73bf3c613.png">


All others will be the same the flow; just deploy the contract and mint nfts; just keep an eye on `baseUri` and `tokenuri` they will have changed. 
This change would need to delete all the collections and again just redeploy them through API 