### PR TITLE
changed the response structure of get nft

### DIFF
--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -250,14 +250,15 @@ export class NftController {
         const bids = await this.nftservice.getBids(auction._id);
         console.log(bids);
         return {
-          nft,
+          ...nft,
           auction,
           bids,
         };
       }
       if (is_nft_exists.is_in_sale) {
+        return 'its in sale will send sale info soon';
       }
-      return nft;
+      return { ...nft };
     } catch (error) {
       console.log(error);
       return { message: 'Something went wrong' };


### PR DESCRIPTION
1. If nft is not in Auction only contract address and  nft details will returned
![image](https://user-images.githubusercontent.com/98945513/201102294-93da44b9-dd17-4b45-8df3-ea4ac2182b99.png)

2.  If Nft is in Auction Contract details and Nft details along with Auction and Bids.

![image](https://user-images.githubusercontent.com/98945513/201102646-44ba56ef-773e-4733-9973-c67b7e9b4cb0.png)
